### PR TITLE
Fix accidental execution of document.write() after document load

### DIFF
--- a/StandalonePHPEnkoder.php
+++ b/StandalonePHPEnkoder.php
@@ -257,14 +257,16 @@ EOT;
     $name = "enkoder_" . strval($this->enkoder_uses) . "_" . strval(rand());
     $this->enkoder_uses += 1;
     $js = <<<EOT
-<span id="$name">$msg</span><script type="text/javascript">
+<span id="$name">$msg</span><script id="script_{$name}" type="text/javascript">
 /* <!-- */
 function hivelogic_$name() {
 var kode="$clean";var i,c,x;while(eval(kode));
 }
 hivelogic_$name();
 var span = document.getElementById('$name');
+var script = document.getElementById('script_$name');
 span.parentNode.removeChild(span);
+script.parentNode.removeChild(script);
 /* --> */
 </script>
 EOT;


### PR DESCRIPTION
Issue: http://stackoverflow.com/questions/2360076/javascript-document-write-replaces-all-body-content-when-using-ajax

You can't use document.write once the document has completed loading.
If you do, the browser will open a new document that replaces
the current.

Same goes for using wrapping functions like jQuery.wrapInner().
