### PR TITLE
Fix multibyte unicode support

### DIFF
--- a/StandalonePHPEnkoder.php
+++ b/StandalonePHPEnkoder.php
@@ -201,9 +201,10 @@ EOT;
     // Our base case -- we'll eventually evaluate this code.
     // Note that we're using innerHTML() since document.write() fails on
     // pages loaded using AJAX.
-    $kode = "document.getElementById('ENKODER_ID').outerHTML=\"" . 
+    // Use escape() + decodeURIComponent() to preserve multibyte unicode
+    $kode = "document.getElementById('ENKODER_ID').outerHTML=decodeURIComponent(escape(\"" . 
       addcslashes($content,"\\\'\"&\n\r<>") . 
-      "\";";
+      "\"));";
 
     $max_length = max($max_length, strlen($kode) + $this->min_length + 1);
     

--- a/StandalonePHPEnkoder.php
+++ b/StandalonePHPEnkoder.php
@@ -266,7 +266,7 @@ EOT;
 <span id="$name">$msg</span><script id="script_{$name}" type="text/javascript">
 /* <!-- */
 function hivelogic_$name() {
-var kode="$clean",i,c,x,script=document.getElementById("script_{$name}");while(kode.indexOf("getElementById('ENKODER_ID')")===-1){eval(kode)};kode=kode.replace('ENKODER_ID','$name');eval(kode);script&&script.parentNode.removeChild(script);
+var kode="$clean",i,c,x,script=document.currentScript||document.getElementById("script_{$name}");while(kode.indexOf("getElementById('ENKODER_ID')")===-1){eval(kode)};kode=kode.replace('ENKODER_ID','$name');eval(kode);script&&script.parentNode.removeChild(script);
 }
 hivelogic_$name();
 /* --> */

--- a/StandalonePHPEnkoder.php
+++ b/StandalonePHPEnkoder.php
@@ -266,7 +266,7 @@ EOT;
 <span id="$name">$msg</span><script id="script_{$name}" type="text/javascript">
 /* <!-- */
 function hivelogic_$name() {
-var kode="$clean",i,c,x,script=document.getElementById("script_{$name}");while(kode.indexOf("getElementById('ENKODER_ID')")===-1){eval(kode)};kode=kode.replace('ENKODER_ID','$name');eval(kode);script.parentNode.removeChild(script);
+var kode="$clean",i,c,x,script=document.getElementById("script_{$name}");while(kode.indexOf("getElementById('ENKODER_ID')")===-1){eval(kode)};kode=kode.replace('ENKODER_ID','$name');eval(kode);script&&script.parentNode.removeChild(script);
 }
 hivelogic_$name();
 /* --> */

--- a/StandalonePHPEnkoder.php
+++ b/StandalonePHPEnkoder.php
@@ -264,12 +264,10 @@ EOT;
     // perform the final eval().
     $js = <<<EOT
 <span id="$name">$msg</span><script id="script_{$name}" type="text/javascript">
-/* <!-- */
 function hivelogic_$name() {
 var kode="$clean",i,c,x,script=document.currentScript||document.getElementById("script_{$name}");while(kode.indexOf("getElementById('ENKODER_ID')")===-1){eval(kode)};kode=kode.replace('ENKODER_ID','$name');eval(kode);script&&script.parentNode.removeChild(script);
 }
 hivelogic_$name();
-/* --> */
 </script>
 EOT;
 


### PR DESCRIPTION
Enkoder does not currently support multibyte characters such as `’`. For example, encoding `don’t` results in `donât`.

This pull request adds full support for unicode characters (including Emoji 😀). It is [based on CloudFlare’s solution][1] and uses `escape()` to percentage encode the final reconstructed string's bytes, and then `decodeURIComponent()` to properly handle unicode characters. 

[1]:https://blog.jse.li/posts/cloudflare-scrape-shield/